### PR TITLE
Bump log4j to 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,11 @@ dependencies {
   implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
   implementation 'org.slf4j:slf4j-api:1.7.26'
 
-  // 2.0 <= Apache log4j <= 2.14.1 contains a 0-day exploit: https://www.lunasec.io/docs/blog/log4j-zero-day/
-  runtimeOnly "org.apache.logging.log4j:log4j-core:2.15.0"
-  runtimeOnly "org.apache.logging.log4j:log4j-api:2.15.0"
+  // 2.0 <= Apache log4j <= 2.15.0 contains a 0-day exploit:
+  //   https://www.lunasec.io/docs/blog/log4j-zero-day
+  //   https://www.lunasec.io/docs/blog/log4j-zero-day-update-on-cve-2021-45046
+  runtimeOnly "org.apache.logging.log4j:log4j-core:2.16.0"
+  runtimeOnly "org.apache.logging.log4j:log4j-api:2.16.0"
 
   implementation 'org.apache.commons:commons-csv:1.6'
   implementation 'com.amazonaws:aws-lambda-java-core:1.1.0'


### PR DESCRIPTION
Bump log4j again to mitigate another vulnerability: https://www.lunasec.io/docs/blog/log4j-zero-day-update-on-cve-2021-45046