### PR TITLE
Bump log4j to 2.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,11 +38,11 @@ dependencies {
   implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
   implementation 'org.slf4j:slf4j-api:1.7.26'
 
-  // 2.0 <= Apache log4j <= 2.15.0 contains a 0-day exploit:
+  // 2.0 <= Apache log4j <= 2.16.0 contains a 0-day exploit:
   //   https://www.lunasec.io/docs/blog/log4j-zero-day
   //   https://www.lunasec.io/docs/blog/log4j-zero-day-update-on-cve-2021-45046
-  runtimeOnly "org.apache.logging.log4j:log4j-core:2.16.0"
-  runtimeOnly "org.apache.logging.log4j:log4j-api:2.16.0"
+  runtimeOnly "org.apache.logging.log4j:log4j-core:2.17.0"
+  runtimeOnly "org.apache.logging.log4j:log4j-api:2.17.0"
 
   implementation 'org.apache.commons:commons-csv:1.6'
   implementation 'com.amazonaws:aws-lambda-java-core:1.1.0'


### PR DESCRIPTION
Bump log4j to mitigate a discovered DoS-vulnerability (also) affecting 2.16.0: https://logging.apache.org/log4j/2.x/security.html