### PR TITLE
Remove references to `incoming`

### DIFF
--- a/doc/transformers/csv.md
+++ b/doc/transformers/csv.md
@@ -13,7 +13,7 @@ Example Lambda event input:
 
 ```json
 {
-  "input": "s3://ok-origo-dataplatform-dev/incoming/green/test/boligpriser.csv",
+  "input": "s3://ok-origo-dataplatform-dev/raw/green/test/boligpriser.csv",
   "output": "s3://ok-origo-dataplatform-dev/intermediate/green/test/boligpriser.csv",
   "csvlt": "def zeroes(length)\n  if ($length < 1)\n    \"\"\n  else\n    \"0\" + zeroes($length - 1)\n\ndef delbydel_id(delbydel_nummer)\n  let nr = string(round(number($delbydel_nummer)))\n  zeroes(4 - size($nr)) + $nr\n\n{\n  \"delbydel_id\": delbydel_id(.Delbydelnummer),\n  \"navn\": .Delbydelsnavn\n}\n",
   "delimiter": ";"

--- a/src/test/kotlin/no/ok/origo/dataplatform/jsontransformer/Json2CsvHandlerTest.kt
+++ b/src/test/kotlin/no/ok/origo/dataplatform/jsontransformer/Json2CsvHandlerTest.kt
@@ -64,7 +64,7 @@ class Json2CsvHandlerTest : S3MockExtension() {
         val handler = Json2CsvHandler(s3Client)
 
         val inputJson = TestUtils.readTestResource("json2csv/json2CsvInput.json")
-        handler.writeToS3("incoming/yellow/input-dataset-id/version=1/edition=20190131T000000/test_data.json", inputJson)
+        handler.writeToS3("raw/yellow/input-dataset-id/version=1/edition=20190131T000000/test_data.json", inputJson)
 
         val output = ByteArrayOutputStream()
         handler.handleRequestWithLogging(lambdaEvent.byteInputStream(), output, ctx)

--- a/src/test/resources/json2csv/json2CsvConfig.json
+++ b/src/test/resources/json2csv/json2CsvConfig.json
@@ -16,7 +16,7 @@
     },
     "step_data": {
       "s3_input_prefixes": {
-        "vedlikeholdsutgifter-renovasjonsbiler": "incoming/yellow/input-dataset-id/version=1/edition=20190131T000000/"
+        "vedlikeholdsutgifter-renovasjonsbiler": "raw/yellow/input-dataset-id/version=1/edition=20190131T000000/"
       },
       "status": "SOME STATUS",
       "errors": []


### PR DESCRIPTION
The `incoming` S3 path was renamed to `raw` in 2020. Remove the remaining references to the old name.